### PR TITLE
Add Metis Snapshot Manager with Two-Tier Backup Strategy

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -96,6 +96,19 @@ reviews:
         - Validate error handling in example code
         - Check documentation clarity and completeness
 
+    # Backup and snapshot tools
+    - path: "tools/backup/**/*.py"
+      instructions: |
+        - Verify arangodump/arangorestore command construction and error handling
+        - Check snapshot metadata integrity and versioning
+        - Validate retention policy logic (last 10, weekly for 3 months, permanent protection)
+        - Ensure proper cleanup and rollback on failures
+        - Review compression/decompression safety
+        - Validate path handling and directory permissions
+        - Check TCP endpoint usage is documented (issue #5 workaround)
+        - Ensure environment variable handling (ARANGO_PASSWORD)
+        - Validate CLI argument parsing and user confirmations
+
   # Tool integration
   tools:
     shellcheck:
@@ -145,3 +158,9 @@ knowledge_base:
     - "Go proxy timeouts: Default 120s client, 10s dial, configurable via env vars"
     - "Import operations: Use on_duplicate='ignore' for idempotent ingestion"
     - "TreeSitter parsing: Handle grammar loading errors, validate language support"
+    - "Backup strategy: Two-tier system - DR (ZFS snapshots, nightly) + operational (arangodump, on-demand)"
+    - "Operational snapshots: Use TCP endpoint (http://127.0.0.1:8529) due to Go proxy limitation (issue #5)"
+    - "Backup defaults: include_bulk=False (bulk storage is already the archive, no need to back up backup)"
+    - "Snapshot retention: Keep last 10, weekly for 3 months, never delete permanent snapshots"
+    - "DR backups: ZFS snapshot of dbpool/arangodb dataset, instant and space-efficient"
+    - "Backup performance: TCP acceptable for backups (not time-sensitive like inference operations)"

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -142,25 +142,21 @@ exclude:
   - "**/go.sum"  # Go dependency checksums
   - "**/*.sock"  # Unix socket files
 
-# Known issues/patterns to watch for
+# Knowledge base for CodeRabbit AI learning
 knowledge_base:
   learnings:
-    - "ArangoDB operations must enforce strict SLOs (p50≤0.4ms upstream, ~0.2ms proxy overhead)"
-    - "Unix socket proxies: RO (0660) allows queries only, RW (0660 dev/0600 prod) allows DB-scoped mutations"
-    - "Proxy security: RO blocks AQL DML keywords (INSERT, UPDATE, REPLACE, REMOVE, UPSERT) using word-boundary regex, RW blocks admin endpoints"
-    - "RO proxy: DELETE allowed for cursor cleanup, PUT to cursor deprecated (use POST)"
-    - "HTTP/2 client: Use persistent connections, handle timeouts properly, cleanup cursors"
-    - "Jina v4: 32k context, 2048 dimensions, late chunking support, batch processing required"
-    - "Socket permissions critical: RO 0660 group access, RW 0660 dev/0600 prod owner-only"
-    - "Admin operations: Must use admin socket or RW socket, idempotent design required"
-    - "Extractor factory: Detect file type by extension, use robust fallback on errors"
-    - "Embedder configuration: Validate device (cuda/cpu), batch size, chunk parameters"
-    - "Go proxy timeouts: Default 120s client, 10s dial, configurable via env vars"
-    - "Import operations: Use on_duplicate='ignore' for idempotent ingestion"
-    - "TreeSitter parsing: Handle grammar loading errors, validate language support"
-    - "Backup strategy: Two-tier system - DR (ZFS snapshots, nightly) + operational (arangodump, on-demand)"
-    - "Operational snapshots: Use TCP endpoint (http://127.0.0.1:8529) due to Go proxy limitation (issue #5)"
-    - "Backup defaults: include_bulk=False (bulk storage is already the archive, no need to back up backup)"
-    - "Snapshot retention: Keep last 10, weekly for 3 months, never delete permanent snapshots"
-    - "DR backups: ZFS snapshot of dbpool/arangodb dataset, instant and space-efficient"
-    - "Backup performance: TCP acceptable for backups (not time-sensitive like inference operations)"
+    scope: auto  # CodeRabbit learns patterns automatically from reviews
+
+# Project-specific conventions and critical patterns
+# These are documented in path_instructions above for CodeRabbit reviews:
+# - ArangoDB operations must enforce strict SLOs (p50≤0.4ms upstream, ~0.2ms proxy overhead)
+# - Unix socket proxies: RO (0660) queries only, RW (0660 dev/0600 prod) DB-scoped mutations
+# - Proxy security: RO blocks AQL DML keywords, RW blocks admin endpoints
+# - HTTP/2 client: persistent connections, proper timeout handling, cursor cleanup
+# - Jina v4: 32k context, 2048 dimensions, late chunking, batch processing
+# - Socket permissions: RO 0660 group, RW 0660 dev/0600 prod owner-only
+# - Backup strategy: Two-tier (DR=ZFS snapshots nightly, operational=arangodump on-demand)
+# - Operational snapshots: TCP endpoint (http://127.0.0.1:8529) due to Go proxy limitation (issue #5)
+# - Backup defaults: include_bulk=False (bulk storage is already the archive)
+# - Snapshot retention: Last 10, weekly for 3 months, permanent snapshots never deleted
+# - Import operations: Use on_duplicate='ignore' for idempotent ingestion

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,20 @@
+"""Root conftest.py for pytest configuration."""
+import sys
+from pathlib import Path
+
+# Ensure project root is in Python path BEFORE any test imports
+# This must run first so that test modules can import tools.*
+project_root = Path(__file__).parent.resolve()
+project_root_str = str(project_root)
+
+# Insert at position 0 to ensure it's checked first
+if project_root_str not in sys.path:
+    sys.path.insert(0, project_root_str)
+
+# Verify tools package is importable
+try:
+    import tools.backup
+except ImportError as e:
+    print(f"WARNING: Cannot import tools.backup: {e}")
+    print(f"Project root: {project_root}")
+    print(f"sys.path: {sys.path[:5]}")

--- a/docs/backup-strategy.md
+++ b/docs/backup-strategy.md
@@ -186,12 +186,14 @@ python -m tools.backup.cli restore metis_20251007_143022_before_cf_validation_ph
 ## When to Use Each
 
 ### Use DR Backup When:
+
 - Hardware failure or disk corruption
 - Complete system restore needed
 - Rolling back all databases to a known state
 - Scheduled maintenance/upgrades
 
 ### Use Operational Snapshot When:
+
 - Starting an experiment that modifies data
 - Testing schema changes on one database
 - Need to rollback without affecting other databases

--- a/docs/backup-strategy.md
+++ b/docs/backup-strategy.md
@@ -244,4 +244,4 @@ du -sh /bulk-store/metis/snapshots/*
 - [Snapshot Manager Quick Reference](../tools/SNAPSHOT_QUICKSTART.md)
 - [Snapshot Manager Full Documentation](../tools/backup/README.md)
 - ZFS Snapshots: `man zfs-snapshot`
-- ArangoDB Backup: https://docs.arangodb.com/stable/operations/backup-and-restore/
+- [ArangoDB Backup](https://docs.arangodb.com/stable/operations/backup-and-restore/)

--- a/docs/backup-strategy.md
+++ b/docs/backup-strategy.md
@@ -1,0 +1,247 @@
+# Metis Backup Strategy
+
+This document describes the two-tier backup system for Metis data and databases.
+
+## Overview
+
+**Two backup systems with different purposes:**
+
+1. **DR Backup (Disaster Recovery)** - Full system snapshots for catastrophic failure
+2. **Operational Snapshots** - Single database backups for experiment rollback
+
+## 1. DR Backup (Disaster Recovery)
+
+**Purpose**: Complete ArangoDB instance backup for disaster recovery
+
+**Scope**: Entire `dbpool/arangodb` dataset (all databases, all collections)
+
+**Method**: ZFS snapshots (instant, copy-on-write)
+
+**Schedule**: Nightly at 2 AM, 30-day retention
+
+**Storage**: On `dbpool` (same pool, minimal space overhead due to COW)
+
+### Manual DR Backup
+
+```bash
+# Create DR snapshot
+sudo zfs snapshot dbpool/arangodb@dr_golden_image_$(date +%Y%m%d_%H%M%S)
+
+# List all DR snapshots
+zfs list -t snapshot -r dbpool/arangodb
+
+# Check snapshot size
+zfs list -t snapshot -r dbpool/arangodb -o name,used,referenced
+```
+
+### DR Restore Procedure
+
+**⚠️ WARNING**: This will restore **ALL databases** to the snapshot state!
+
+```bash
+# 1. Stop ArangoDB
+sudo systemctl stop arangodb3
+
+# 2. Rollback to snapshot
+sudo zfs rollback dbpool/arangodb@dr_golden_image_20251007_122624
+
+# 3. Start ArangoDB
+sudo systemctl start arangodb3
+
+# 4. Verify
+sudo systemctl status arangodb3
+```
+
+### Automated Nightly DR Backups
+
+**Cron configuration** in `/etc/cron.d/metis-dr-backup`:
+
+```cron
+# Metis DR Backup - Nightly ZFS snapshot of ArangoDB
+# Runs at 2 AM daily, keeps last 30 snapshots
+
+0 2 * * * root /usr/local/bin/metis-dr-backup.sh
+```
+
+**Backup script** at `/usr/local/bin/metis-dr-backup.sh`:
+
+```bash
+#!/bin/bash
+#
+# Metis DR Backup Script
+# Creates nightly ZFS snapshot of entire ArangoDB instance
+# Retains last 30 snapshots (30 days)
+#
+
+set -euo pipefail
+
+DATASET="dbpool/arangodb"
+SNAPSHOT_PREFIX="dr_nightly"
+RETENTION_DAYS=30
+
+# Create timestamp
+TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+SNAPSHOT_NAME="${DATASET}@${SNAPSHOT_PREFIX}_${TIMESTAMP}"
+
+# Create snapshot
+echo "$(date): Creating DR snapshot: ${SNAPSHOT_NAME}"
+zfs snapshot "${SNAPSHOT_NAME}"
+
+if [ $? -eq 0 ]; then
+    echo "$(date): ✓ DR snapshot created successfully"
+else
+    echo "$(date): ✗ DR snapshot failed!" >&2
+    exit 1
+fi
+
+# Clean up old snapshots (keep last 30)
+echo "$(date): Cleaning up old DR snapshots..."
+zfs list -t snapshot -r "${DATASET}" -o name -s creation | \
+    grep "${SNAPSHOT_PREFIX}" | \
+    head -n -${RETENTION_DAYS} | \
+    while read snapshot; do
+        echo "$(date): Deleting old snapshot: ${snapshot}"
+        zfs destroy "${snapshot}"
+    done
+
+echo "$(date): DR backup complete"
+```
+
+### Setup Instructions
+
+```bash
+# 1. Create backup script
+sudo tee /usr/local/bin/metis-dr-backup.sh > /dev/null << 'EOF'
+[paste script above]
+EOF
+
+# 2. Make executable
+sudo chmod +x /usr/local/bin/metis-dr-backup.sh
+
+# 3. Test manually
+sudo /usr/local/bin/metis-dr-backup.sh
+
+# 4. Create cron job
+sudo tee /etc/cron.d/metis-dr-backup > /dev/null << 'EOF'
+# Metis DR Backup - Nightly ZFS snapshot of ArangoDB
+0 2 * * * root /usr/local/bin/metis-dr-backup.sh >> /var/log/metis-dr-backup.log 2>&1
+EOF
+
+# 5. Verify cron job
+sudo crontab -l | grep metis
+```
+
+## 2. Operational Snapshots
+
+**Purpose**: On-demand backup of single database before experiments
+
+**Scope**: Single database (e.g., `arxiv_datastore`) only
+
+**Method**: `arangodump` for granular database export
+
+**Schedule**: On-demand via CLI
+
+**Storage**: `/bulk-store/metis/snapshots/`
+
+### Create Operational Snapshot
+
+```bash
+# Before CF validation or experiments
+cd ~/olympus/metis
+python -m tools.backup.cli create "Before CF validation Phase 4" --database arxiv_datastore
+```
+
+### Restore Operational Snapshot
+
+```bash
+# List available snapshots
+python -m tools.backup.cli list
+
+# Restore specific database only (does NOT affect other databases)
+python -m tools.backup.cli restore metis_20251007_143022_before_cf_validation_phase_4
+```
+
+### Key Differences from DR Backup
+
+- **Granular**: Restores only one database, not entire ArangoDB instance
+- **Selective**: Can restore while other databases keep running
+- **Portable**: Dump files can be moved to other systems
+- **Slower**: Takes time to dump/restore vs instant ZFS snapshots
+
+**Full documentation**: [tools/backup/README.md](../tools/backup/README.md)
+
+## Comparison Matrix
+
+| Feature | DR Backup | Operational Snapshot |
+|---------|-----------|---------------------|
+| **Scope** | All databases | Single database |
+| **Method** | ZFS snapshot | arangodump |
+| **Speed** | Instant | Minutes |
+| **Storage** | dbpool (COW) | bulk-store |
+| **Schedule** | Nightly (automated) | On-demand (manual) |
+| **Use Case** | Hardware failure, corruption | Experiment rollback |
+| **Granularity** | Entire ArangoDB | One database |
+| **Downtime** | Requires ArangoDB restart | No restart needed |
+
+## When to Use Each
+
+### Use DR Backup When:
+- Hardware failure or disk corruption
+- Complete system restore needed
+- Rolling back all databases to a known state
+- Scheduled maintenance/upgrades
+
+### Use Operational Snapshot When:
+- Starting an experiment that modifies data
+- Testing schema changes on one database
+- Need to rollback without affecting other databases
+- Want portable backup for migration
+
+## Monitoring
+
+### Check DR Snapshot Status
+
+```bash
+# List all DR snapshots
+zfs list -t snapshot -r dbpool/arangodb
+
+# Check space used by snapshots
+zfs list -t snapshot -r dbpool/arangodb -o name,used,referenced
+
+# See how much has changed since snapshot
+zfs diff dbpool/arangodb@dr_golden_image_20251007_122624
+```
+
+### Check Operational Snapshot Status
+
+```bash
+# List operational snapshots
+python -m tools.backup.cli list --verbose
+
+# Check snapshot storage usage
+du -sh /bulk-store/metis/snapshots/*
+```
+
+## Log Files
+
+- **DR backups**: `/var/log/metis-dr-backup.log`
+- **Operational snapshots**: stdout/stderr from CLI
+
+## Success Criteria
+
+**DR Backup Test:**
+- ✅ Create DR snapshot: `sudo zfs snapshot dbpool/arangodb@dr_golden_image_$(date +%Y%m%d)`
+- ✅ Verify snapshot exists: `zfs list -t snapshot -r dbpool/arangodb`
+- ✅ Test restore on non-production system (optional)
+
+**Operational Snapshot Test:**
+- ✅ Create golden-image: `python -m tools.backup.cli create "golden-image-phase3"`
+- ✅ Verify backup: `python -m tools.backup.cli list`
+- ✅ Test restore: Create, modify data, restore, verify rollback
+
+## Related Documentation
+
+- [Snapshot Manager Quick Reference](../tools/SNAPSHOT_QUICKSTART.md)
+- [Snapshot Manager Full Documentation](../tools/backup/README.md)
+- ZFS Snapshots: `man zfs-snapshot`
+- ArangoDB Backup: https://docs.arangodb.com/stable/operations/backup-and-restore/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,10 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Topic :: Database",
 ]
-packages = [{ include = "metis" }]
+packages = [
+    { include = "metis" },
+    { include = "tools" }
+]
 
 [tool.poetry.dependencies]
 python = ">=3.11,<3.14"  # triton requires <3.14

--- a/tests/test_tools/__init__.py
+++ b/tests/test_tools/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for Metis tools."""

--- a/tests/test_tools/test_snapshot_manager.py
+++ b/tests/test_tools/test_snapshot_manager.py
@@ -1,0 +1,560 @@
+"""
+Tests for Metis Snapshot Manager.
+
+Run with: pytest tests/tools/test_snapshot_manager.py -v
+"""
+
+import json
+import shutil
+import sys
+import tempfile
+from datetime import datetime, timedelta
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Add project root to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from tools.backup.snapshot_manager import (
+    SnapshotError,
+    SnapshotManager,
+    SnapshotMetadata,
+)
+
+
+@pytest.fixture
+def temp_dirs():
+    """Create temporary directories for testing."""
+    snapshot_dir = Path(tempfile.mkdtemp(prefix="metis_snapshots_"))
+    bulk_store_dir = Path(tempfile.mkdtemp(prefix="metis_bulk_"))
+
+    # Create test bulk store structure
+    (bulk_store_dir / "experiments").mkdir()
+    (bulk_store_dir / "experiments" / "test.txt").write_text("test data")
+
+    yield {
+        "snapshot_root": snapshot_dir,
+        "bulk_store_root": bulk_store_dir,
+    }
+
+    # Cleanup
+    shutil.rmtree(snapshot_dir, ignore_errors=True)
+    shutil.rmtree(bulk_store_dir, ignore_errors=True)
+
+
+@pytest.fixture
+def mock_manager(temp_dirs):
+    """Create SnapshotManager with mocked database operations."""
+    manager = SnapshotManager(
+        db_name="test_db",
+        db_socket="/tmp/test.sock",
+        db_username="test",
+        db_password="test",
+        snapshot_root=temp_dirs["snapshot_root"],
+        bulk_store_root=temp_dirs["bulk_store_root"],
+    )
+
+    # Mock database operations with side effects to create directories
+    def mock_backup_side_effect(output_dir: Path):
+        """Mock backup that creates the database directory."""
+        output_dir.mkdir(parents=True, exist_ok=True)
+        # Create a fake dump file
+        (output_dir / "test_collection.data.json").write_text('{"test": "data"}')
+        return {
+            "test_collection": 100,
+            "another_collection": 50,
+        }
+
+    def mock_restore_side_effect(input_dir: Path):
+        """Mock restore that verifies directory exists."""
+        if not input_dir.exists():
+            raise SnapshotError(f"Database backup not found: {input_dir}")
+        return None
+
+    with patch.object(
+        manager, "_backup_database", side_effect=mock_backup_side_effect
+    ), patch.object(manager, "_restore_database", side_effect=mock_restore_side_effect):
+        yield manager
+
+
+class TestSnapshotMetadata:
+    """Test SnapshotMetadata dataclass."""
+
+    def test_metadata_creation(self):
+        """Test creating snapshot metadata."""
+        metadata = SnapshotMetadata(
+            snapshot_name="test_snapshot",
+            timestamp="2025-10-07T14:30:00",
+            description="Test snapshot",
+            git_commit="abc123",
+            git_branch="main",
+            permanent=False,
+            collections={"test": 100},
+            bulk_store_size_mb=1.5,
+            database_size_mb=2.0,
+            compression=None,
+        )
+
+        assert metadata.snapshot_name == "test_snapshot"
+        assert metadata.permanent is False
+        assert metadata.collections == {"test": 100}
+
+    def test_metadata_to_dict(self):
+        """Test converting metadata to dictionary."""
+        metadata = SnapshotMetadata(
+            snapshot_name="test_snapshot",
+            timestamp="2025-10-07T14:30:00",
+            description="Test",
+            git_commit=None,
+            git_branch=None,
+            permanent=True,
+            collections={"test": 50},
+            bulk_store_size_mb=1.0,
+            database_size_mb=2.0,
+            compression="gzip",
+        )
+
+        data = metadata.__dict__
+        assert data["permanent"] is True
+        assert data["compression"] == "gzip"
+
+
+class TestSnapshotManager:
+    """Test SnapshotManager core functionality."""
+
+    def test_initialization(self, temp_dirs):
+        """Test SnapshotManager initialization."""
+        manager = SnapshotManager(
+            snapshot_root=temp_dirs["snapshot_root"],
+            bulk_store_root=temp_dirs["bulk_store_root"],
+        )
+
+        assert manager.snapshot_root == temp_dirs["snapshot_root"]
+        assert manager.bulk_store_root == temp_dirs["bulk_store_root"]
+        assert manager.snapshot_root.exists()
+
+    def test_create_snapshot(self, mock_manager):
+        """Test creating a snapshot."""
+        snapshot_name = mock_manager.create_snapshot(
+            description="test_snapshot",
+            permanent=False,
+            include_bulk=True,
+        )
+
+        # Verify snapshot name format
+        assert snapshot_name.startswith("metis_")
+        assert "test_snapshot" in snapshot_name
+
+        # Verify snapshot directory exists
+        snapshot_dir = mock_manager.snapshot_root / snapshot_name
+        assert snapshot_dir.exists()
+
+        # Verify metadata file
+        metadata_file = snapshot_dir / "metadata.json"
+        assert metadata_file.exists()
+
+        metadata = json.loads(metadata_file.read_text())
+        assert metadata["description"] == "test_snapshot"
+        assert metadata["permanent"] is False
+        assert "test_collection" in metadata["collections"]
+
+        # Verify bulk storage was copied
+        bulk_dir = snapshot_dir / "bulk_store" / "experiments"
+        assert bulk_dir.exists()
+        assert (bulk_dir / "test.txt").exists()
+
+    def test_create_snapshot_no_bulk(self, mock_manager):
+        """Test creating snapshot without bulk storage."""
+        snapshot_name = mock_manager.create_snapshot(
+            description="db_only",
+            permanent=False,
+            include_bulk=False,
+        )
+
+        snapshot_dir = mock_manager.snapshot_root / snapshot_name
+        assert snapshot_dir.exists()
+        assert (snapshot_dir / "database").exists()
+        assert not (snapshot_dir / "bulk_store").exists()
+
+    def test_create_permanent_snapshot(self, mock_manager):
+        """Test creating permanent snapshot."""
+        snapshot_name = mock_manager.create_snapshot(
+            description="permanent_test",
+            permanent=True,
+            include_bulk=True,
+        )
+
+        snapshots = mock_manager.list_snapshots()
+        snapshot = next(s for s in snapshots if s.snapshot_name == snapshot_name)
+        assert snapshot.permanent is True
+
+    def test_list_snapshots_empty(self, mock_manager):
+        """Test listing snapshots when none exist."""
+        snapshots = mock_manager.list_snapshots()
+        assert len(snapshots) == 0
+
+    def test_list_snapshots(self, mock_manager):
+        """Test listing multiple snapshots."""
+        # Create multiple snapshots
+        names = []
+        for i in range(3):
+            name = mock_manager.create_snapshot(
+                description=f"test_{i}",
+                permanent=(i == 0),
+                include_bulk=False,
+            )
+            names.append(name)
+
+        # List and verify
+        snapshots = mock_manager.list_snapshots()
+        assert len(snapshots) == 3
+
+        # Verify sorting (most recent first)
+        snapshot_names = [s.snapshot_name for s in snapshots]
+        assert snapshot_names == sorted(names, reverse=True)
+
+        # Verify permanent flag
+        assert snapshots[-1].permanent is True  # First created (i==0)
+
+    def test_restore_snapshot_requires_confirmation(self, mock_manager):
+        """Test that restore requires explicit confirmation."""
+        snapshot_name = mock_manager.create_snapshot(
+            description="test_restore",
+            permanent=False,
+            include_bulk=False,
+        )
+
+        # Should raise error without confirm=True
+        with pytest.raises(SnapshotError, match="confirm=True"):
+            mock_manager.restore_snapshot(
+                snapshot_name=snapshot_name,
+                confirm=False,
+                restore_bulk=False,
+            )
+
+    def test_restore_snapshot(self, mock_manager):
+        """Test restoring a snapshot."""
+        # Create snapshot
+        snapshot_name = mock_manager.create_snapshot(
+            description="test_restore",
+            permanent=False,
+            include_bulk=True,
+        )
+
+        # Restore
+        success = mock_manager.restore_snapshot(
+            snapshot_name=snapshot_name,
+            confirm=True,
+            restore_bulk=True,
+        )
+        assert success is True
+
+    def test_restore_nonexistent_snapshot(self, mock_manager):
+        """Test restoring snapshot that doesn't exist."""
+        with pytest.raises(SnapshotError, match="not found"):
+            mock_manager.restore_snapshot(
+                snapshot_name="nonexistent",
+                confirm=True,
+                restore_bulk=False,
+            )
+
+    def test_delete_snapshot(self, mock_manager):
+        """Test deleting a snapshot."""
+        snapshot_name = mock_manager.create_snapshot(
+            description="test_delete",
+            permanent=False,
+            include_bulk=False,
+        )
+
+        # Verify exists
+        snapshots = mock_manager.list_snapshots()
+        assert len(snapshots) == 1
+
+        # Delete
+        mock_manager.delete_snapshot(snapshot_name)
+
+        # Verify deleted
+        snapshots = mock_manager.list_snapshots()
+        assert len(snapshots) == 0
+
+    def test_delete_permanent_snapshot_fails(self, mock_manager):
+        """Test that deleting permanent snapshot fails."""
+        snapshot_name = mock_manager.create_snapshot(
+            description="permanent",
+            permanent=True,
+            include_bulk=False,
+        )
+
+        with pytest.raises(SnapshotError, match="marked permanent"):
+            mock_manager.delete_snapshot(snapshot_name)
+
+    def test_delete_nonexistent_snapshot(self, mock_manager):
+        """Test deleting snapshot that doesn't exist."""
+        with pytest.raises(SnapshotError, match="not found"):
+            mock_manager.delete_snapshot("nonexistent")
+
+    def test_calculate_directory_size(self, mock_manager, temp_dirs):
+        """Test calculating directory size."""
+        test_dir = temp_dirs["bulk_store_root"] / "test_size"
+        test_dir.mkdir()
+        (test_dir / "file1.txt").write_text("x" * 1000)  # 1KB
+        (test_dir / "file2.txt").write_text("x" * 2000)  # 2KB
+
+        size_mb = mock_manager._calculate_directory_size(test_dir)
+        assert size_mb > 0
+        assert size_mb < 0.01  # Should be ~0.003 MB
+
+    def test_get_git_info(self, mock_manager):
+        """Test getting git information."""
+        with patch("subprocess.run") as mock_run:
+            # Mock two subprocess calls: one for commit, one for branch
+            mock_run.side_effect = [
+                MagicMock(returncode=0, stdout="abc123def456\n"),  # commit
+                MagicMock(returncode=0, stdout="main\n"),          # branch
+            ]
+
+            commit, branch = mock_manager._get_git_info()
+
+            assert commit == "abc123def456"
+            assert branch == "main"
+
+    def test_get_git_info_not_git_repo(self, mock_manager):
+        """Test getting git info when not in a git repo."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value.returncode = 1
+
+            commit, branch = mock_manager._get_git_info()
+
+            assert commit is None
+            assert branch is None
+
+
+class TestRetentionPolicy:
+    """Test snapshot retention policy."""
+
+    def create_test_snapshot_metadata(
+        self,
+        manager: SnapshotManager,
+        name: str,
+        days_ago: int,
+        permanent: bool = False,
+    ):
+        """Helper to create snapshot metadata with custom timestamp."""
+        timestamp = datetime.now() - timedelta(days=days_ago)
+        snapshot_dir = manager.snapshot_root / name
+        snapshot_dir.mkdir()
+
+        # Create database directory to make it look like a real snapshot
+        (snapshot_dir / "database").mkdir()
+
+        metadata = SnapshotMetadata(
+            snapshot_name=name,
+            timestamp=timestamp.isoformat(),
+            description=f"Test snapshot {days_ago} days ago",
+            git_commit=None,
+            git_branch=None,
+            permanent=permanent,
+            collections={"test": 10},
+            bulk_store_size_mb=1.0,
+            database_size_mb=1.0,
+            compression=None,
+        )
+
+        metadata_file = snapshot_dir / "metadata.json"
+        metadata_file.write_text(json.dumps(metadata.__dict__, indent=2))
+
+    def test_retention_keeps_last_10(self, mock_manager):
+        """Test that retention policy keeps last 10 snapshots."""
+        # Create 15 snapshots all older than 3 months (so weekly policy doesn't apply)
+        for i in range(15):
+            self.create_test_snapshot_metadata(
+                mock_manager,
+                f"metis_snapshot_{i:02d}",
+                days_ago=100 + i,  # All beyond 3 months
+                permanent=False,
+            )
+
+        # Apply policy
+        mock_manager.apply_retention_policy(dry_run=False)
+
+        # Should keep only 10 (most recent 10 of the old snapshots)
+        snapshots = mock_manager.list_snapshots()
+        assert len(snapshots) == 10
+
+    def test_retention_keeps_permanent(self, mock_manager):
+        """Test that permanent snapshots are never deleted."""
+        # Create old permanent snapshot
+        self.create_test_snapshot_metadata(
+            mock_manager,
+            "metis_permanent_old",
+            days_ago=365,
+            permanent=True,
+        )
+
+        # Create 10 newer snapshots
+        for i in range(10):
+            self.create_test_snapshot_metadata(
+                mock_manager,
+                f"metis_snapshot_{i:02d}",
+                days_ago=i,
+                permanent=False,
+            )
+
+        # Apply policy
+        mock_manager.apply_retention_policy(dry_run=False)
+
+        # Permanent snapshot should still exist
+        snapshots = mock_manager.list_snapshots()
+        snapshot_names = [s.snapshot_name for s in snapshots]
+        assert "metis_permanent_old" in snapshot_names
+
+    def test_retention_keeps_weekly(self, mock_manager):
+        """Test that weekly snapshots are kept for 3 months."""
+        # Create snapshots spanning 100 days
+        for i in range(0, 100, 7):  # Weekly
+            self.create_test_snapshot_metadata(
+                mock_manager,
+                f"metis_weekly_{i:03d}",
+                days_ago=i,
+                permanent=False,
+            )
+
+        # Apply policy
+        mock_manager.apply_retention_policy(dry_run=False)
+
+        # Should keep snapshots within 90 days
+        snapshots = mock_manager.list_snapshots()
+        assert len(snapshots) > 0
+
+        # Check that very old weekly snapshots are deleted
+        snapshot_names = [s.snapshot_name for s in snapshots]
+        assert "metis_weekly_098" not in snapshot_names  # 98 days ago
+
+    def test_retention_dry_run(self, mock_manager):
+        """Test retention policy dry run doesn't delete."""
+        # Create 15 snapshots
+        for i in range(15):
+            self.create_test_snapshot_metadata(
+                mock_manager,
+                f"metis_snapshot_{i:02d}",
+                days_ago=i,
+                permanent=False,
+            )
+
+        initial_count = len(mock_manager.list_snapshots())
+
+        # Dry run
+        mock_manager.apply_retention_policy(dry_run=True)
+
+        # Should not delete anything
+        final_count = len(mock_manager.list_snapshots())
+        assert final_count == initial_count
+
+
+class TestCompression:
+    """Test snapshot compression."""
+
+    def test_compress_snapshot(self, mock_manager):
+        """Test compressing a snapshot."""
+        # Create snapshot
+        snapshot_name = mock_manager.create_snapshot(
+            description="test_compress",
+            permanent=False,
+            include_bulk=False,
+        )
+
+        snapshot_dir = mock_manager.snapshot_root / snapshot_name
+
+        # Compress
+        mock_manager._compress_snapshot(snapshot_dir)
+
+        # Verify tar.gz exists
+        tar_file = Path(str(snapshot_dir) + ".tar.gz")
+        assert tar_file.exists()
+
+        # Verify original directory exists but only has metadata.json
+        # (compression extracts metadata back for listing purposes)
+        assert snapshot_dir.exists()
+        assert (snapshot_dir / "metadata.json").exists()
+        assert not (snapshot_dir / "database").exists()  # Database files are compressed
+
+    def test_decompress_snapshot(self, mock_manager):
+        """Test decompressing a snapshot."""
+        # Create and compress snapshot
+        snapshot_name = mock_manager.create_snapshot(
+            description="test_decompress",
+            permanent=False,
+            include_bulk=False,
+        )
+
+        snapshot_dir = mock_manager.snapshot_root / snapshot_name
+
+        # Load metadata before compression
+        metadata_path = snapshot_dir / "metadata.json"
+        with open(metadata_path) as f:
+            metadata_dict = json.load(f)
+
+        mock_manager._compress_snapshot(snapshot_dir)
+
+        tar_file = Path(str(snapshot_dir) + ".tar.gz")
+        assert tar_file.exists()
+
+        # Update metadata with compression info
+        metadata_dict["compression"] = "tar.gz"
+        metadata = SnapshotMetadata.from_dict(metadata_dict)
+
+        # Decompress
+        decompressed_path = mock_manager._decompress_snapshot(snapshot_dir, metadata)
+
+        # Verify directory exists
+        assert decompressed_path.exists()
+        assert (decompressed_path / "metadata.json").exists()
+
+
+class TestEdgeCases:
+    """Test edge cases and error handling."""
+
+    def test_empty_description(self, mock_manager):
+        """Test creating snapshot with empty description."""
+        # Should work but use empty string
+        snapshot_name = mock_manager.create_snapshot(
+            description="",
+            permanent=False,
+            include_bulk=False,
+        )
+
+        assert snapshot_name.startswith("metis_")
+
+    def test_special_characters_in_description(self, mock_manager):
+        """Test description with special characters."""
+        # Spaces and hyphens should work
+        snapshot_name = mock_manager.create_snapshot(
+            description="test-snapshot with spaces",
+            permanent=False,
+            include_bulk=False,
+        )
+
+        assert "test-snapshot" in snapshot_name or "test_snapshot" in snapshot_name
+
+    def test_restore_compressed_snapshot(self, mock_manager):
+        """Test restoring a compressed snapshot."""
+        # Create snapshot
+        snapshot_name = mock_manager.create_snapshot(
+            description="test_compressed_restore",
+            permanent=False,
+            include_bulk=False,
+        )
+
+        # Compress it
+        snapshot_dir = mock_manager.snapshot_root / snapshot_name
+        mock_manager._compress_snapshot(snapshot_dir)
+
+        # Restore should handle decompression automatically
+        success = mock_manager.restore_snapshot(
+            snapshot_name=snapshot_name,
+            confirm=True,
+            restore_bulk=False,
+        )
+        assert success is True

--- a/tools/README.md
+++ b/tools/README.md
@@ -6,7 +6,7 @@ Production infrastructure and data processing tools for the Metis semantic knowl
 
 ### `backup/`
 
-**Snapshot manager for ArangoDB and bulk storage backup/restore**
+#### Snapshot manager for ArangoDB and bulk storage backup/restore
 
 Comprehensive backup system enabling safe experimentation with rollback capability.
 
@@ -18,6 +18,7 @@ Comprehensive backup system enabling safe experimentation with rollback capabili
 - Git commit/branch tracking
 
 **Quick Start:**
+
 ```bash
 # Take snapshot
 python -m tools.backup.cli create "Before experiment"

--- a/tools/README.md
+++ b/tools/README.md
@@ -4,6 +4,37 @@ Production infrastructure and data processing tools for the Metis semantic knowl
 
 ## Directory Structure
 
+### `backup/`
+
+**Snapshot manager for ArangoDB and bulk storage backup/restore**
+
+Comprehensive backup system enabling safe experimentation with rollback capability.
+
+**Key Features:**
+- Full system snapshots (database + bulk storage)
+- Automatic retention policy (last 10, weekly for 3 months)
+- Permanent snapshot flag for milestones
+- CLI interface with safety confirmations
+- Git commit/branch tracking
+
+**Quick Start:**
+```bash
+# Take snapshot
+python -m tools.backup.cli create "Before experiment"
+
+# List snapshots
+python -m tools.backup.cli list
+
+# Restore if needed
+python -m tools.backup.cli restore <snapshot_name>
+```
+
+**Documentation:**
+- [Quick Reference](SNAPSHOT_QUICKSTART.md) - Essential commands
+- [Full Documentation](backup/README.md) - Detailed workflows and examples
+
+**Status:** ✅ Production ready - 26/26 tests passing
+
 ### `arxiv_import/`
 
 **Production pipeline for importing arXiv papers into ArangoDB**

--- a/tools/SNAPSHOT_QUICKSTART.md
+++ b/tools/SNAPSHOT_QUICKSTART.md
@@ -1,0 +1,78 @@
+# Snapshot Manager Quick Reference
+
+**Location**: `tools/backup/`
+**Full Documentation**: [tools/backup/README.md](backup/README.md)
+
+## Essential Commands
+
+```bash
+# Create snapshot
+python -m tools.backup.cli create "Description here"
+
+# List snapshots
+python -m tools.backup.cli list
+
+# Restore snapshot
+python -m tools.backup.cli restore <snapshot_name>
+
+# Delete snapshot
+python -m tools.backup.cli delete <snapshot_name>
+
+# Cleanup old snapshots
+python -m tools.backup.cli cleanup --dry-run
+```
+
+## Before CF Validation Phase 4
+
+```bash
+# 1. Take snapshot
+python -m tools.backup.cli create "Before CF validation Phase 4"
+
+# 2. Run your experiments
+cd experiments/word2vec
+python your_experiment.py
+
+# 3. If something goes wrong, restore
+python -m tools.backup.cli list
+python -m tools.backup.cli restore metis_YYYYMMDD_HHMMSS_before_cf_validation_phase_4
+```
+
+## Key Points
+
+- **Snapshots backup**: ArangoDB database + `/bulk-store/metis/` files
+- **Location**: `/bulk-store/metis/snapshots/`
+- **Restore is destructive**: Always confirms before replacing data
+- **Retention**: Keeps last 10, weekly for 3 months, permanent snapshots forever
+- **Compression**: Automatic after 1 week (tar.gz)
+
+## Common Flags
+
+- `--permanent` - Never auto-delete this snapshot
+- `--no-bulk` - Database only (skip bulk storage)
+- `--yes` - Skip confirmation prompts
+- `--verbose` - Show detailed information
+- `--dry-run` - Preview without making changes
+
+## Examples
+
+```bash
+# Permanent snapshot at milestone
+python -m tools.backup.cli create "Word2Vec dataset complete" --permanent
+
+# Quick database-only snapshot
+python -m tools.backup.cli create "Before schema change" --no-bulk
+
+# Restore with auto-confirm (careful!)
+python -m tools.backup.cli restore metis_20251007_143022_baseline --yes
+
+# See what cleanup would delete
+python -m tools.backup.cli cleanup --dry-run
+```
+
+## Help
+
+```bash
+python -m tools.backup.cli --help
+python -m tools.backup.cli create --help
+python -m tools.backup.cli restore --help
+```

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,1 @@
+"""Metis operational tools and utilities."""

--- a/tools/backup/README.md
+++ b/tools/backup/README.md
@@ -1,0 +1,289 @@
+# Metis Snapshot Manager
+
+Backup and restore system for ArangoDB databases and bulk storage files. Enables safe experimentation with rollback capability.
+
+## Features
+
+- **Full System Snapshots**: Backs up both ArangoDB collections and bulk storage files
+- **Retention Policy**: Automatically manages snapshot lifecycle
+  - Keeps last 10 snapshots
+  - Keeps weekly snapshots for 3 months
+  - Compresses snapshots older than 1 week
+- **Permanent Snapshots**: Flag important snapshots to never be auto-deleted
+- **Git Integration**: Tracks git commit and branch in snapshot metadata
+- **Safety Features**: Requires explicit confirmation for destructive operations
+
+## Installation
+
+The snapshot manager is part of the Metis tools package. No additional installation needed.
+
+## Usage
+
+### Create a Snapshot
+
+```bash
+# Basic snapshot
+python -m tools.backup.cli create "Before major refactor"
+
+# Permanent snapshot (never auto-deleted)
+python -m tools.backup.cli create "Production baseline" --permanent
+
+# Database only (skip bulk storage)
+python -m tools.backup.cli create "Quick checkpoint" --no-bulk
+```
+
+### List Snapshots
+
+```bash
+# List all snapshots
+python -m tools.backup.cli list
+
+# Detailed view with collection counts
+python -m tools.backup.cli list --verbose
+```
+
+Example output:
+```
+Found 3 snapshot(s):
+
+📌 metis_20251007_143022_production_baseline [compressed]
+   Production baseline before v2.0 deployment
+   Created: 2025-10-07T14:30:22
+   5 collections, 125430 docs, 2.4 GB total
+
+📦 metis_20251007_120045_before_major_refactor
+   Before major refactor
+   Created: 2025-10-07T12:00:45
+   5 collections, 98234 docs, 1.8 GB total
+```
+
+### Restore a Snapshot
+
+```bash
+# Interactive restore (prompts for confirmation)
+python -m tools.backup.cli restore metis_20251007_143022_production_baseline
+
+# Skip confirmation prompt
+python -m tools.backup.cli restore metis_20251007_143022_production_baseline --yes
+
+# Restore database only (skip bulk storage)
+python -m tools.backup.cli restore metis_20251007_143022_production_baseline --no-bulk
+```
+
+⚠️ **Warning**: Restoration will **REPLACE** your current database and bulk storage!
+
+### Delete a Snapshot
+
+```bash
+# Interactive delete (prompts for confirmation)
+python -m tools.backup.cli delete metis_20251007_120045_before_major_refactor
+
+# Skip confirmation prompt
+python -m tools.backup.cli delete metis_20251007_120045_before_major_refactor --yes
+
+# Force delete permanent snapshot
+python -m tools.backup.cli delete metis_20251007_143022_production_baseline --force --yes
+```
+
+### Cleanup Old Snapshots
+
+Apply retention policy to remove old snapshots:
+
+```bash
+# Dry run (show what would be deleted)
+python -m tools.backup.cli cleanup --dry-run
+
+# Apply cleanup
+python -m tools.backup.cli cleanup
+```
+
+## Retention Policy
+
+The snapshot manager automatically applies a retention policy:
+
+1. **Keep Last 10**: Always keeps the 10 most recent snapshots
+2. **Weekly for 3 Months**: Keeps one snapshot per week for 3 months
+3. **Permanent Protection**: Never deletes snapshots marked as permanent
+4. **Automatic Compression**: Compresses snapshots older than 1 week using tar.gz
+
+### How It Works
+
+When creating a new snapshot or running `cleanup`, the system:
+1. Identifies snapshots eligible for deletion
+2. Excludes the last 10 snapshots
+3. Excludes weekly snapshots from the last 3 months
+4. Excludes permanent snapshots
+5. Deletes remaining snapshots
+6. Compresses snapshots older than 1 week
+
+## Storage Layout
+
+Snapshots are stored in `/bulk-store/metis/snapshots/`:
+
+```
+/bulk-store/metis/snapshots/
+├── metis_20251007_143022_production_baseline/
+│   ├── metadata.json              # Snapshot metadata
+│   ├── database/                  # ArangoDB dump
+│   │   ├── arxiv_markdown.data.json
+│   │   ├── arxiv_code.data.json
+│   │   └── cf_embeddings.data.json
+│   └── bulk_store/                # Bulk storage files
+│       └── experiments/
+└── metis_20251007_120045_before_major_refactor.tar.gz  # Compressed
+```
+
+## Programmatic Usage
+
+You can also use the snapshot manager programmatically:
+
+```python
+from tools.backup import SnapshotManager
+
+# Initialize
+manager = SnapshotManager()
+
+# Create snapshot
+snapshot_name = manager.create_snapshot(
+    description="Before experiment",
+    permanent=False,
+    include_bulk=True,
+)
+
+# List snapshots
+snapshots = manager.list_snapshots()
+for snapshot in snapshots:
+    print(f"{snapshot.snapshot_name}: {snapshot.description}")
+
+# Restore snapshot
+manager.restore_snapshot(
+    snapshot_name=snapshot_name,
+    confirm=True,  # Must be True for safety
+    restore_bulk=True,
+)
+
+# Apply retention policy
+manager.apply_retention_policy(dry_run=False)
+```
+
+## Best Practices
+
+### When to Create Snapshots
+
+- **Before major changes**: Refactoring, schema changes, bulk updates
+- **Before experiments**: Testing new algorithms, parameter tuning
+- **Periodic backups**: Daily/weekly production snapshots
+- **Release milestones**: Mark as permanent for version baselines
+
+### Snapshot Naming
+
+The snapshot name is auto-generated: `metis_YYYYMMDD_HHMMSS_description`
+
+- Use descriptive names: "before_schema_migration", "baseline_v2.0"
+- Keep descriptions concise (will be part of filename)
+- Avoid special characters (use underscores/hyphens)
+
+### Managing Storage
+
+- Compression reduces size by ~70% for text-heavy data
+- Monitor `/bulk-store/metis/snapshots/` disk usage
+- Run `cleanup` regularly to apply retention policy
+- Use `--no-bulk` for quick database-only snapshots
+- Mark important snapshots as `--permanent`
+
+## Troubleshooting
+
+### "Snapshot directory already exists"
+
+A snapshot with the same timestamp already exists. Wait a second and try again, or manually remove the directory.
+
+### "arangodump not found"
+
+Install ArangoDB tools:
+```bash
+# Ubuntu/Debian
+sudo apt-get install arangodb3-client
+```
+
+### "Permission denied" on socket
+
+Ensure your user is in the `metis` group:
+```bash
+sudo usermod -aG metis $USER
+# Log out and back in
+```
+
+### Restore fails with "database not empty"
+
+By default, `arangorestore` creates collections. If collections exist, it may fail. The snapshot manager handles this automatically, but if you see errors, check ArangoDB logs.
+
+### Out of disk space
+
+- Run `cleanup --dry-run` to see what can be deleted
+- Delete old snapshots manually if needed
+- Consider storing snapshots on a separate volume
+
+## Integration Testing
+
+To test the snapshot manager:
+
+```bash
+# 1. Create test data in ArangoDB
+python -c "from experiments.word2vec.storage import Storage; s = Storage(); print('Test data ready')"
+
+# 2. Create snapshot
+python -m tools.backup.cli create "integration_test"
+
+# 3. Modify data (delete a collection, change documents, etc.)
+
+# 4. List snapshots
+python -m tools.backup.cli list --verbose
+
+# 5. Restore snapshot
+python -m tools.backup.cli restore metis_YYYYMMDD_HHMMSS_integration_test --yes
+
+# 6. Verify data restored correctly
+
+# 7. Cleanup
+python -m tools.backup.cli delete metis_YYYYMMDD_HHMMSS_integration_test --yes
+```
+
+## Technical Details
+
+### Database Backup
+
+Uses `arangodump` with:
+- Unix socket connection for performance
+- System collections excluded
+- Overwrite mode enabled
+- Per-collection document counts captured
+
+### Bulk Storage Backup
+
+Uses `rsync` with:
+- Archive mode (`-av`)
+- Excludes: `.tmp`, `__pycache__`, `.git`
+- Efficient incremental copying
+- Preserves permissions and timestamps
+
+### Compression
+
+Uses `tar.gz` compression:
+- Applied to snapshots older than 1 week
+- Compresses database dumps and bulk storage together
+- Automatic decompression during restoration
+- Reduces storage by ~70% for text-heavy data
+
+### Git Tracking
+
+Captures git metadata at snapshot creation:
+- Current commit hash (full SHA)
+- Current branch name
+- Stored in `metadata.json`
+- Helps correlate snapshots with code versions
+
+## See Also
+
+- [ArangoDB Backup Documentation](https://docs.arangodb.com/stable/operations/backup-and-restore/)
+- [rsync Manual](https://linux.die.net/man/1/rsync)
+- Metis project documentation: `/home/todd/olympus/metis/README.md`

--- a/tools/backup/README.md
+++ b/tools/backup/README.md
@@ -59,7 +59,8 @@ python -m tools.backup.cli list --verbose
 ```
 
 Example output:
-```
+
+```text
 Found 3 snapshot(s):
 
 📌 metis_20251007_143022_production_baseline [compressed]
@@ -215,6 +216,7 @@ python -m tools.backup.cli restore metis_20251007_120000_before_schema_migration
 - Excludes: `.tmp`, `__pycache__`, `.git`
 
 **Metadata (JSON file):**
+
 ```json
 {
   "snapshot_name": "metis_20251007_143022_before_cf_validation_phase_4",
@@ -257,7 +259,7 @@ When creating a new snapshot or running `cleanup`, the system:
 
 Snapshots are stored in `/bulk-store/metis/snapshots/`:
 
-```
+```text
 /bulk-store/metis/snapshots/
 ├── metis_20251007_143022_production_baseline/
 │   ├── metadata.json              # Snapshot metadata
@@ -337,6 +339,7 @@ A snapshot with the same timestamp already exists. Wait a second and try again, 
 ### "arangodump not found"
 
 Install ArangoDB tools:
+
 ```bash
 # Ubuntu/Debian
 sudo apt-get install arangodb3-client
@@ -345,6 +348,7 @@ sudo apt-get install arangodb3-client
 ### "Permission denied" on socket
 
 Ensure your user is in the `metis` group:
+
 ```bash
 sudo usermod -aG metis $USER
 # Log out and back in

--- a/tools/backup/__init__.py
+++ b/tools/backup/__init__.py
@@ -1,0 +1,9 @@
+"""
+Metis Snapshot Manager
+
+Provides snapshot/backup capabilities for ArangoDB and bulk storage files.
+"""
+
+from .snapshot_manager import SnapshotManager, SnapshotMetadata
+
+__all__ = ["SnapshotManager", "SnapshotMetadata"]

--- a/tools/backup/cli.py
+++ b/tools/backup/cli.py
@@ -178,7 +178,7 @@ def delete_snapshot_cmd(args: argparse.Namespace) -> int:
                 print("Deletion cancelled.")
                 return 0
 
-        manager.delete_snapshot(args.snapshot_name)
+        manager.delete_snapshot(args.snapshot_name, force=args.force)
         print(f"✓ Snapshot deleted: {args.snapshot_name}")
         return 0
 

--- a/tools/backup/cli.py
+++ b/tools/backup/cli.py
@@ -1,0 +1,322 @@
+"""
+Command-line interface for Metis Snapshot Manager.
+
+Usage:
+    metis snapshot create "description" [--permanent]
+    metis snapshot list [--verbose]
+    metis snapshot restore snapshot_name [--yes]
+    metis snapshot delete snapshot_name [--force]
+    metis snapshot cleanup [--dry-run]
+"""
+
+import argparse
+import sys
+from typing import Optional
+
+from .snapshot_manager import SnapshotError, SnapshotManager
+
+
+def create_snapshot_cmd(args: argparse.Namespace) -> int:
+    """Handle 'create' command."""
+    try:
+        manager = SnapshotManager()
+        print(f"Creating snapshot: {args.description}")
+
+        snapshot_name = manager.create_snapshot(
+            description=args.description,
+            permanent=args.permanent,
+            include_bulk=not args.no_bulk,
+        )
+
+        print(f"✓ Snapshot created: {snapshot_name}")
+
+        # Show snapshot details
+        snapshots = manager.list_snapshots()
+        snapshot = next((s for s in snapshots if s.snapshot_name == snapshot_name), None)
+        if snapshot:
+            print("\nDetails:")
+            print(f"  Collections: {sum(snapshot.collections.values())} documents")
+            print(f"  Database: {snapshot.database_size_mb:.2f} MB")
+            print(f"  Bulk storage: {snapshot.bulk_store_size_mb:.2f} MB")
+            if snapshot.git_commit:
+                print(f"  Git: {snapshot.git_branch}@{snapshot.git_commit[:8]}")
+
+        return 0
+
+    except SnapshotError as e:
+        print(f"✗ Error: {e}", file=sys.stderr)
+        return 1
+    except Exception as e:
+        print(f"✗ Unexpected error: {e}", file=sys.stderr)
+        return 1
+
+
+def list_snapshots_cmd(args: argparse.Namespace) -> int:
+    """Handle 'list' command."""
+    try:
+        manager = SnapshotManager()
+        snapshots = manager.list_snapshots()
+
+        if not snapshots:
+            print("No snapshots found.")
+            return 0
+
+        print(f"Found {len(snapshots)} snapshot(s):\n")
+
+        for snapshot in snapshots:
+            # Basic info
+            marker = "📌" if snapshot.permanent else "📦"
+            compressed = " [compressed]" if snapshot.compression else ""
+            print(f"{marker} {snapshot.snapshot_name}{compressed}")
+            print(f"   {snapshot.description}")
+            print(f"   Created: {snapshot.timestamp}")
+
+            if args.verbose:
+                # Detailed info
+                print("   Collections:")
+                for coll, count in sorted(snapshot.collections.items()):
+                    print(f"     - {coll}: {count} documents")
+                print(f"   Database size: {snapshot.database_size_mb:.2f} MB")
+                print(f"   Bulk storage: {snapshot.bulk_store_size_mb:.2f} MB")
+                if snapshot.git_commit:
+                    print(f"   Git: {snapshot.git_branch}@{snapshot.git_commit[:8]}")
+            else:
+                # Summary
+                total_docs = sum(snapshot.collections.values())
+                total_size = snapshot.database_size_mb + snapshot.bulk_store_size_mb
+                print(f"   {total_docs} docs, {total_size:.2f} MB total")
+
+            print()
+
+        return 0
+
+    except SnapshotError as e:
+        print(f"✗ Error: {e}", file=sys.stderr)
+        return 1
+    except Exception as e:
+        print(f"✗ Unexpected error: {e}", file=sys.stderr)
+        return 1
+
+
+def restore_snapshot_cmd(args: argparse.Namespace) -> int:
+    """Handle 'restore' command."""
+    try:
+        manager = SnapshotManager()
+
+        # Load snapshot metadata to show what will be restored
+        snapshots = manager.list_snapshots()
+        snapshot = next((s for s in snapshots if s.snapshot_name == args.snapshot_name), None)
+
+        if not snapshot:
+            print(f"✗ Snapshot not found: {args.snapshot_name}", file=sys.stderr)
+            return 1
+
+        # Show what will be restored
+        print(f"Restore snapshot: {snapshot.snapshot_name}")
+        print(f"  Description: {snapshot.description}")
+        print(f"  Created: {snapshot.timestamp}")
+        print(f"  Collections: {sum(snapshot.collections.values())} documents")
+        print(f"  Database: {snapshot.database_size_mb:.2f} MB")
+        print(f"  Bulk storage: {snapshot.bulk_store_size_mb:.2f} MB")
+
+        # Confirmation
+        if not args.yes:
+            print("\n⚠️  WARNING: This will REPLACE current database and bulk storage!")
+            response = input("Type 'yes' to confirm restoration: ")
+            if response.lower() != "yes":
+                print("Restoration cancelled.")
+                return 0
+
+        print("\nRestoring snapshot...")
+        success = manager.restore_snapshot(
+            snapshot_name=args.snapshot_name,
+            confirm=True,
+            restore_bulk=not args.no_bulk,
+        )
+
+        if success:
+            print("✓ Snapshot restored successfully")
+            return 0
+        else:
+            print("✗ Restoration failed", file=sys.stderr)
+            return 1
+
+    except SnapshotError as e:
+        print(f"✗ Error: {e}", file=sys.stderr)
+        return 1
+    except Exception as e:
+        print(f"✗ Unexpected error: {e}", file=sys.stderr)
+        return 1
+
+
+def delete_snapshot_cmd(args: argparse.Namespace) -> int:
+    """Handle 'delete' command."""
+    try:
+        manager = SnapshotManager()
+
+        # Load snapshot metadata
+        snapshots = manager.list_snapshots()
+        snapshot = next((s for s in snapshots if s.snapshot_name == args.snapshot_name), None)
+
+        if not snapshot:
+            print(f"✗ Snapshot not found: {args.snapshot_name}", file=sys.stderr)
+            return 1
+
+        # Check if permanent
+        if snapshot.permanent and not args.force:
+            print("✗ Cannot delete permanent snapshot without --force flag", file=sys.stderr)
+            return 1
+
+        # Confirmation
+        if not args.yes:
+            print(f"Delete snapshot: {snapshot.snapshot_name}")
+            print(f"  Description: {snapshot.description}")
+            if snapshot.permanent:
+                print("  ⚠️  This is a PERMANENT snapshot!")
+            response = input("Type 'yes' to confirm deletion: ")
+            if response.lower() != "yes":
+                print("Deletion cancelled.")
+                return 0
+
+        manager.delete_snapshot(args.snapshot_name)
+        print(f"✓ Snapshot deleted: {args.snapshot_name}")
+        return 0
+
+    except SnapshotError as e:
+        print(f"✗ Error: {e}", file=sys.stderr)
+        return 1
+    except Exception as e:
+        print(f"✗ Unexpected error: {e}", file=sys.stderr)
+        return 1
+
+
+def cleanup_snapshots_cmd(args: argparse.Namespace) -> int:
+    """Handle 'cleanup' command."""
+    try:
+        manager = SnapshotManager()
+
+        print("Applying retention policy...")
+        if args.dry_run:
+            print("(DRY RUN - no changes will be made)")
+
+        manager.apply_retention_policy(dry_run=args.dry_run)
+
+        if args.dry_run:
+            print("\n✓ Dry run complete. Use without --dry-run to apply changes.")
+        else:
+            print("\n✓ Cleanup complete.")
+
+        return 0
+
+    except SnapshotError as e:
+        print(f"✗ Error: {e}", file=sys.stderr)
+        return 1
+    except Exception as e:
+        print(f"✗ Unexpected error: {e}", file=sys.stderr)
+        return 1
+
+
+def main(argv: Optional[list] = None) -> int:
+    """Main CLI entry point."""
+    parser = argparse.ArgumentParser(
+        description="Metis Snapshot Manager - Backup and restore ArangoDB and bulk storage",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+
+    subparsers = parser.add_subparsers(dest="command", help="Command to execute")
+    subparsers.required = True
+
+    # Create command
+    create_parser = subparsers.add_parser(
+        "create",
+        help="Create a new snapshot",
+    )
+    create_parser.add_argument(
+        "description",
+        help="Description of the snapshot",
+    )
+    create_parser.add_argument(
+        "--permanent",
+        action="store_true",
+        help="Mark snapshot as permanent (never auto-deleted)",
+    )
+    create_parser.add_argument(
+        "--no-bulk",
+        action="store_true",
+        help="Skip bulk storage backup (database only)",
+    )
+    create_parser.set_defaults(func=create_snapshot_cmd)
+
+    # List command
+    list_parser = subparsers.add_parser(
+        "list",
+        help="List all snapshots",
+    )
+    list_parser.add_argument(
+        "--verbose", "-v",
+        action="store_true",
+        help="Show detailed information",
+    )
+    list_parser.set_defaults(func=list_snapshots_cmd)
+
+    # Restore command
+    restore_parser = subparsers.add_parser(
+        "restore",
+        help="Restore from a snapshot",
+    )
+    restore_parser.add_argument(
+        "snapshot_name",
+        help="Name of snapshot to restore",
+    )
+    restore_parser.add_argument(
+        "--yes",
+        action="store_true",
+        help="Skip confirmation prompt",
+    )
+    restore_parser.add_argument(
+        "--no-bulk",
+        action="store_true",
+        help="Skip bulk storage restore (database only)",
+    )
+    restore_parser.set_defaults(func=restore_snapshot_cmd)
+
+    # Delete command
+    delete_parser = subparsers.add_parser(
+        "delete",
+        help="Delete a snapshot",
+    )
+    delete_parser.add_argument(
+        "snapshot_name",
+        help="Name of snapshot to delete",
+    )
+    delete_parser.add_argument(
+        "--yes",
+        action="store_true",
+        help="Skip confirmation prompt",
+    )
+    delete_parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Force deletion of permanent snapshots",
+    )
+    delete_parser.set_defaults(func=delete_snapshot_cmd)
+
+    # Cleanup command
+    cleanup_parser = subparsers.add_parser(
+        "cleanup",
+        help="Apply retention policy to remove old snapshots",
+    )
+    cleanup_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be deleted without actually deleting",
+    )
+    cleanup_parser.set_defaults(func=cleanup_snapshots_cmd)
+
+    # Parse and execute
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/backup/cli.py
+++ b/tools/backup/cli.py
@@ -25,7 +25,7 @@ def create_snapshot_cmd(args: argparse.Namespace) -> int:
         snapshot_name = manager.create_snapshot(
             description=args.description,
             permanent=args.permanent,
-            include_bulk=not args.no_bulk,
+            include_bulk=args.include_bulk,
         )
 
         print(f"✓ Snapshot created: {snapshot_name}")
@@ -241,9 +241,9 @@ def main(argv: Optional[list] = None) -> int:
         help="Mark snapshot as permanent (never auto-deleted)",
     )
     create_parser.add_argument(
-        "--no-bulk",
+        "--include-bulk",
         action="store_true",
-        help="Skip bulk storage backup (database only)",
+        help="Include bulk storage backup (rarely needed - bulk storage is already the archive)",
     )
     create_parser.set_defaults(func=create_snapshot_cmd)
 

--- a/tools/backup/snapshot_manager.py
+++ b/tools/backup/snapshot_manager.py
@@ -1,0 +1,638 @@
+"""
+Snapshot Manager for ArangoDB and Bulk Storage
+
+Provides reliable snapshot/restore functionality for safe experimentation.
+"""
+
+import json
+import logging
+import shutil
+import subprocess
+import tarfile
+from dataclasses import asdict, dataclass
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SnapshotMetadata:
+    """Metadata for a database/storage snapshot."""
+
+    snapshot_name: str
+    timestamp: str  # ISO format
+    description: str
+    git_commit: Optional[str]
+    git_branch: Optional[str]
+    permanent: bool
+    collections: Dict[str, int]  # collection_name -> document_count
+    bulk_store_size_mb: float
+    database_size_mb: float
+    compression: Optional[str]  # None, "gzip", "tar.gz"
+
+    @classmethod
+    def from_dict(cls, data: Dict) -> "SnapshotMetadata":
+        """Create metadata from dictionary."""
+        return cls(**data)
+
+    def to_dict(self) -> Dict:
+        """Convert metadata to dictionary."""
+        return asdict(self)
+
+
+class SnapshotError(Exception):
+    """Base exception for snapshot operations."""
+
+    pass
+
+
+class SnapshotManager:
+    """
+    Manages snapshots of ArangoDB database and bulk storage files.
+
+    Provides create, restore, list, and delete operations with automatic
+    retention policy management.
+    """
+
+    def __init__(
+        self,
+        db_name: str = "arxiv_datastore",
+        db_socket: str = "/run/metis/readwrite/arangod.sock",
+        db_username: str = "root",
+        db_password: str = "",
+        snapshot_root: Path = Path("/bulk-store/metis/snapshots"),
+        bulk_store_root: Path = Path("/bulk-store/metis"),
+    ):
+        """
+        Initialize snapshot manager.
+
+        Args:
+            db_name: ArangoDB database name
+            db_socket: Unix socket path for ArangoDB
+            db_username: Database username
+            db_password: Database password
+            snapshot_root: Directory for storing snapshots
+            bulk_store_root: Root directory of bulk storage to backup
+        """
+        self.db_name = db_name
+        self.db_socket = db_socket
+        self.db_username = db_username
+        self.db_password = db_password
+        self.snapshot_root = Path(snapshot_root)
+        self.bulk_store_root = Path(bulk_store_root)
+
+        # Ensure snapshot directory exists
+        self.snapshot_root.mkdir(parents=True, exist_ok=True)
+
+        logger.info(f"SnapshotManager initialized: {self.snapshot_root}")
+
+    def create_snapshot(
+        self,
+        description: str,
+        permanent: bool = False,
+        include_bulk: bool = True,
+    ) -> str:
+        """
+        Create new snapshot of database and bulk storage.
+
+        Args:
+            description: Human-readable description
+            permanent: If True, won't be auto-deleted by retention policy
+            include_bulk: If True, backup bulk storage files
+
+        Returns:
+            Snapshot name (identifier for restoration)
+
+        Raises:
+            SnapshotError: If snapshot creation fails
+        """
+        logger.info(f"Creating snapshot: {description}")
+
+        # Generate snapshot name
+        timestamp = datetime.now()
+        timestamp_str = timestamp.strftime("%Y%m%d_%H%M%S")
+        safe_desc = description.replace(" ", "_").replace("/", "_").lower()[:40]
+        snapshot_name = f"metis_{timestamp_str}_{safe_desc}"
+
+        # Create snapshot directory
+        snapshot_path = self.snapshot_root / snapshot_name
+        try:
+            snapshot_path.mkdir(parents=True, exist_ok=False)
+        except FileExistsError:
+            raise SnapshotError(f"Snapshot {snapshot_name} already exists")
+
+        try:
+            # Get git information
+            git_commit, git_branch = self._get_git_info()
+
+            # Backup database
+            logger.info("Backing up database...")
+            db_path = snapshot_path / "database"
+            collections = self._backup_database(db_path)
+            db_size_mb = self._calculate_directory_size(db_path)
+
+            # Backup bulk storage if requested
+            bulk_size_mb = 0.0
+            if include_bulk:
+                logger.info("Backing up bulk storage...")
+                bulk_path = snapshot_path / "bulk_store"
+                self._backup_bulk_storage(bulk_path)
+                bulk_size_mb = self._calculate_directory_size(bulk_path)
+
+            # Create metadata
+            metadata = SnapshotMetadata(
+                snapshot_name=snapshot_name,
+                timestamp=timestamp.isoformat(),
+                description=description,
+                git_commit=git_commit,
+                git_branch=git_branch,
+                permanent=permanent,
+                collections=collections,
+                bulk_store_size_mb=bulk_size_mb,
+                database_size_mb=db_size_mb,
+                compression=None,
+            )
+
+            # Save metadata
+            metadata_path = snapshot_path / "metadata.json"
+            with open(metadata_path, "w") as f:
+                json.dump(metadata.to_dict(), f, indent=2)
+
+            logger.info(
+                f"✓ Snapshot created: {snapshot_name} "
+                f"(DB: {db_size_mb:.1f}MB, Bulk: {bulk_size_mb:.1f}MB)"
+            )
+
+            # Apply retention policy (cleanup old snapshots)
+            if not permanent:
+                self.apply_retention_policy()
+
+            return snapshot_name
+
+        except Exception as e:
+            # Cleanup partial snapshot on failure
+            logger.error(f"Snapshot creation failed: {e}")
+            if snapshot_path.exists():
+                shutil.rmtree(snapshot_path)
+            raise SnapshotError(f"Failed to create snapshot: {e}") from e
+
+    def list_snapshots(self, verbose: bool = False) -> List[SnapshotMetadata]:
+        """
+        List all available snapshots.
+
+        Args:
+            verbose: If True, include detailed information
+
+        Returns:
+            List of snapshot metadata, sorted by timestamp (newest first)
+        """
+        snapshots = []
+
+        for snapshot_dir in self.snapshot_root.iterdir():
+            if not snapshot_dir.is_dir():
+                continue
+
+            metadata_path = snapshot_dir / "metadata.json"
+            if not metadata_path.exists():
+                logger.warning(f"No metadata found for {snapshot_dir.name}")
+                continue
+
+            try:
+                with open(metadata_path) as f:
+                    data = json.load(f)
+                metadata = SnapshotMetadata.from_dict(data)
+                snapshots.append(metadata)
+            except Exception as e:
+                logger.warning(f"Failed to load metadata for {snapshot_dir.name}: {e}")
+
+        # Sort by timestamp, newest first
+        snapshots.sort(key=lambda s: s.timestamp, reverse=True)
+
+        return snapshots
+
+    def restore_snapshot(
+        self,
+        snapshot_name: str,
+        confirm: bool = False,
+        restore_bulk: bool = True,
+    ) -> bool:
+        """
+        Restore database and bulk storage from snapshot.
+
+        Args:
+            snapshot_name: Snapshot identifier
+            confirm: Must be True to actually restore (safety check)
+            restore_bulk: If True, restore bulk storage files
+
+        Returns:
+            True if restoration successful
+
+        Raises:
+            SnapshotError: If restoration fails
+        """
+        if not confirm:
+            raise SnapshotError(
+                "restore_snapshot requires confirm=True for safety. "
+                "This will overwrite current database and files!"
+            )
+
+        snapshot_path = self.snapshot_root / snapshot_name
+        if not snapshot_path.exists():
+            raise SnapshotError(f"Snapshot not found: {snapshot_name}")
+
+        logger.info(f"Restoring snapshot: {snapshot_name}")
+
+        # Load metadata
+        metadata_path = snapshot_path / "metadata.json"
+        if not metadata_path.exists():
+            raise SnapshotError(f"Metadata not found for snapshot: {snapshot_name}")
+
+        with open(metadata_path) as f:
+            metadata = SnapshotMetadata.from_dict(json.load(f))
+
+        # Check if compressed
+        if metadata.compression:
+            logger.info(f"Decompressing snapshot ({metadata.compression})...")
+            snapshot_path = self._decompress_snapshot(snapshot_path, metadata)
+
+        try:
+            # Restore database
+            db_path = snapshot_path / "database"
+            if not db_path.exists():
+                raise SnapshotError("Database backup not found in snapshot")
+
+            logger.info("Restoring database...")
+            self._restore_database(db_path)
+
+            # Restore bulk storage if requested
+            if restore_bulk:
+                bulk_path = snapshot_path / "bulk_store"
+                if bulk_path.exists():
+                    logger.info("Restoring bulk storage...")
+                    self._restore_bulk_storage(bulk_path)
+                else:
+                    logger.warning("No bulk storage backup found in snapshot")
+
+            logger.info(f"✓ Snapshot restored: {snapshot_name}")
+            logger.info(f"  Collections restored: {len(metadata.collections)}")
+            logger.info(f"  Total documents: {sum(metadata.collections.values())}")
+
+            return True
+
+        except Exception as e:
+            logger.error(f"Restoration failed: {e}")
+            raise SnapshotError(f"Failed to restore snapshot: {e}") from e
+
+    def delete_snapshot(
+        self,
+        snapshot_name: str,
+        force: bool = False,
+    ) -> bool:
+        """
+        Delete a snapshot.
+
+        Args:
+            snapshot_name: Snapshot identifier
+            force: If True, delete even if marked permanent
+
+        Returns:
+            True if deletion successful
+
+        Raises:
+            SnapshotError: If deletion fails
+        """
+        snapshot_path = self.snapshot_root / snapshot_name
+        if not snapshot_path.exists():
+            raise SnapshotError(f"Snapshot not found: {snapshot_name}")
+
+        # Load metadata to check if permanent
+        metadata_path = snapshot_path / "metadata.json"
+        if metadata_path.exists():
+            with open(metadata_path) as f:
+                metadata = SnapshotMetadata.from_dict(json.load(f))
+
+            if metadata.permanent and not force:
+                raise SnapshotError(
+                    f"Snapshot {snapshot_name} is marked permanent. "
+                    f"Use force=True to delete anyway."
+                )
+
+        # Delete snapshot directory
+        try:
+            shutil.rmtree(snapshot_path)
+            logger.info(f"✓ Snapshot deleted: {snapshot_name}")
+            return True
+        except Exception as e:
+            raise SnapshotError(f"Failed to delete snapshot: {e}") from e
+
+    def apply_retention_policy(self, dry_run: bool = False):
+        """
+        Apply retention policy to clean up old snapshots.
+
+        Policy:
+        - Keep last 10 snapshots
+        - Keep weekly snapshots for 3 months
+        - Never delete permanent snapshots
+        - Compress snapshots older than 1 week
+
+        Args:
+            dry_run: If True, don't actually delete, just report
+        """
+        logger.info("Applying retention policy...")
+
+        snapshots = self.list_snapshots()
+        now = datetime.now()
+        one_week_ago = now - timedelta(weeks=1)
+        three_months_ago = now - timedelta(days=90)
+
+        # Separate permanent and non-permanent snapshots
+        permanent = [s for s in snapshots if s.permanent]
+        non_permanent = [s for s in snapshots if not s.permanent]
+
+        # Keep last 10 non-permanent snapshots
+        to_keep = set()
+        to_delete = []
+
+        # Keep most recent 10
+        to_keep.update(s.snapshot_name for s in non_permanent[:10])
+
+        # Keep weekly snapshots within 3 months
+        weekly_kept = {}
+        for snapshot in non_permanent:
+            snap_date = datetime.fromisoformat(snapshot.timestamp)
+            if snap_date < three_months_ago:
+                continue
+
+            week_key = snap_date.strftime("%Y-W%W")
+            if week_key not in weekly_kept:
+                weekly_kept[week_key] = snapshot.snapshot_name
+                to_keep.add(snapshot.snapshot_name)
+
+        # Determine what to delete
+        for snapshot in non_permanent:
+            if snapshot.snapshot_name not in to_keep:
+                snap_date = datetime.fromisoformat(snapshot.timestamp)
+                if snap_date < three_months_ago:
+                    to_delete.append(snapshot.snapshot_name)
+
+        # Compress old snapshots
+        to_compress = []
+        for snapshot in snapshots:
+            if snapshot.compression is None:
+                snap_date = datetime.fromisoformat(snapshot.timestamp)
+                if snap_date < one_week_ago:
+                    to_compress.append(snapshot.snapshot_name)
+
+        # Execute deletions
+        if to_delete:
+            logger.info(f"Deleting {len(to_delete)} old snapshots...")
+            for name in to_delete:
+                if not dry_run:
+                    try:
+                        self.delete_snapshot(name, force=False)
+                    except Exception as e:
+                        logger.warning(f"Failed to delete {name}: {e}")
+                else:
+                    logger.info(f"  Would delete: {name}")
+
+        # Execute compressions
+        if to_compress:
+            logger.info(f"Compressing {len(to_compress)} old snapshots...")
+            for name in to_compress:
+                if not dry_run:
+                    try:
+                        self._compress_snapshot(name)
+                    except Exception as e:
+                        logger.warning(f"Failed to compress {name}: {e}")
+                else:
+                    logger.info(f"  Would compress: {name}")
+
+        logger.info(
+            f"✓ Retention policy applied: "
+            f"{len(permanent)} permanent, "
+            f"{len(to_keep)} kept, "
+            f"{len(to_delete)} deleted, "
+            f"{len(to_compress)} compressed"
+        )
+
+    # Private helper methods
+
+    def _backup_database(self, output_dir: Path) -> Dict[str, int]:
+        """
+        Backup ArangoDB using arangodump.
+
+        Returns:
+            Dictionary of collection_name -> document_count
+        """
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        cmd = [
+            "arangodump",
+            "--server.database",
+            self.db_name,
+            "--server.endpoint",
+            f"unix://{self.db_socket}",
+            "--server.username",
+            self.db_username,
+            "--output-directory",
+            str(output_dir),
+            "--overwrite",
+            "true",
+            "--include-system-collections",
+            "false",
+        ]
+
+        if self.db_password:
+            cmd.extend(["--server.password", self.db_password])
+
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        if result.returncode != 0:
+            raise SnapshotError(f"Database backup failed: {result.stderr}")
+
+        # Parse collection counts from output
+        collections = {}
+        for line in result.stdout.split("\n"):
+            if "Processed" in line and "document(s)" in line:
+                # Example: "Processed 5 document(s) in 0.001s for collection 'arxiv_markdown'"
+                parts = line.split()
+                if len(parts) >= 6:
+                    try:
+                        count = int(parts[1])
+                        coll_name = parts[-1].strip("'\"")
+                        collections[coll_name] = count
+                    except (ValueError, IndexError):
+                        pass
+
+        return collections
+
+    def _restore_database(self, backup_dir: Path):
+        """Restore ArangoDB using arangorestore."""
+        cmd = [
+            "arangorestore",
+            "--server.database",
+            self.db_name,
+            "--server.endpoint",
+            f"unix://{self.db_socket}",
+            "--server.username",
+            self.db_username,
+            "--input-directory",
+            str(backup_dir),
+            "--overwrite",
+            "true",
+            "--create-database",
+            "true",
+        ]
+
+        if self.db_password:
+            cmd.extend(["--server.password", self.db_password])
+
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        if result.returncode != 0:
+            raise SnapshotError(f"Database restore failed: {result.stderr}")
+
+    def _backup_bulk_storage(self, output_dir: Path):
+        """Backup bulk storage files using rsync."""
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        # Only backup experiments/ directory to avoid unnecessary files
+        source = self.bulk_store_root / "experiments"
+        if not source.exists():
+            logger.warning(f"Bulk storage source not found: {source}")
+            return
+
+        cmd = [
+            "rsync",
+            "-av",
+            "--exclude",
+            "*.tmp",
+            "--exclude",
+            "__pycache__",
+            "--exclude",
+            ".git",
+            str(source) + "/",
+            str(output_dir / "experiments") + "/",
+        ]
+
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        if result.returncode != 0:
+            raise SnapshotError(f"Bulk storage backup failed: {result.stderr}")
+
+    def _restore_bulk_storage(self, backup_dir: Path):
+        """Restore bulk storage files using rsync."""
+        source = backup_dir / "experiments"
+        target = self.bulk_store_root / "experiments"
+
+        if not source.exists():
+            logger.warning("No experiments directory in backup")
+            return
+
+        target.parent.mkdir(parents=True, exist_ok=True)
+
+        cmd = [
+            "rsync",
+            "-av",
+            "--delete",  # Remove files not in backup
+            str(source) + "/",
+            str(target) + "/",
+        ]
+
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        if result.returncode != 0:
+            raise SnapshotError(f"Bulk storage restore failed: {result.stderr}")
+
+    def _compress_snapshot(self, snapshot_name: str | Path):
+        """Compress a snapshot to save space."""
+        # Handle both string name and Path object
+        if isinstance(snapshot_name, Path):
+            snapshot_path = snapshot_name
+            snapshot_name = snapshot_path.name
+        else:
+            snapshot_path = self.snapshot_root / snapshot_name
+
+        # Load metadata
+        metadata_path = snapshot_path / "metadata.json"
+        with open(metadata_path) as f:
+            metadata = SnapshotMetadata.from_dict(json.load(f))
+
+        if metadata.compression:
+            logger.debug(f"Snapshot {snapshot_name} already compressed")
+            return
+
+        # Create tar.gz archive
+        archive_path = snapshot_path.with_suffix(".tar.gz")
+        with tarfile.open(archive_path, "w:gz") as tar:
+            tar.add(snapshot_path, arcname=snapshot_name)
+
+        # Remove original directory (keep only compressed)
+        shutil.rmtree(snapshot_path)
+
+        # Extract metadata.json from archive and update it to mark as compressed
+        with tarfile.open(archive_path, "r:gz") as tar:
+            metadata_member = tar.getmember(f"{snapshot_name}/metadata.json")
+            tar.extract(metadata_member, path=self.snapshot_root)
+
+        # Update extracted metadata to mark as compressed
+        extracted_metadata_path = self.snapshot_root / snapshot_name / "metadata.json"
+        metadata.compression = "tar.gz"
+        with open(extracted_metadata_path, "w") as f:
+            json.dump(metadata.to_dict(), f, indent=2)
+
+        logger.info(f"✓ Compressed snapshot: {snapshot_name}")
+
+    def _decompress_snapshot(
+        self, snapshot_path: Path, metadata: SnapshotMetadata
+    ) -> Path:
+        """
+        Decompress a snapshot for restoration.
+
+        Returns:
+            Path to decompressed snapshot directory
+        """
+        if metadata.compression == "tar.gz":
+            archive_path = snapshot_path.with_suffix(".tar.gz")
+            if not archive_path.exists():
+                raise SnapshotError(f"Compressed archive not found: {archive_path}")
+
+            # Extract to temporary location
+            temp_dir = self.snapshot_root / f"{metadata.snapshot_name}_temp"
+            with tarfile.open(archive_path, "r:gz") as tar:
+                tar.extractall(path=temp_dir)
+
+            return temp_dir / metadata.snapshot_name
+
+        return snapshot_path
+
+    def _get_git_info(self) -> tuple[Optional[str], Optional[str]]:
+        """Get current git commit and branch."""
+        try:
+            # Get commit hash
+            result = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                capture_output=True,
+                text=True,
+                cwd=Path(__file__).parent.parent.parent,
+            )
+            commit = result.stdout.strip() if result.returncode == 0 else None
+
+            # Get branch name
+            result = subprocess.run(
+                ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+                capture_output=True,
+                text=True,
+                cwd=Path(__file__).parent.parent.parent,
+            )
+            branch = result.stdout.strip() if result.returncode == 0 else None
+
+            return commit, branch
+        except Exception:
+            return None, None
+
+    def _calculate_directory_size(self, directory: Path) -> float:
+        """Calculate directory size in MB."""
+        total = 0
+        for entry in directory.rglob("*"):
+            if entry.is_file():
+                total += entry.stat().st_size
+        return total / (1024 * 1024)  # Convert to MB

--- a/tools/backup/snapshot_manager.py
+++ b/tools/backup/snapshot_manager.py
@@ -13,6 +13,7 @@ from dataclasses import asdict, dataclass
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Dict, List, Optional
+import os
 
 logger = logging.getLogger(__name__)
 
@@ -81,8 +82,6 @@ class SnapshotManager:
             because arangodump is not yet supported by the Go security proxies (issue #5).
             This is acceptable for backups since they're not time-sensitive operations.
         """
-        import os
-
         self.db_name = db_name
         self.db_endpoint = db_endpoint  # TCP for backups only
         self.db_username = db_username


### PR DESCRIPTION
## Summary

Implements comprehensive two-tier backup system for Metis:
1. **DR Backup** - ZFS snapshots for disaster recovery (instant, space-efficient)
2. **Operational Snapshots** - arangodump for granular database rollback

This enables safe experimentation with rollback capability before CF validation Phase 4.

## Features

### DR Backup System (Disaster Recovery)
- ✅ **ZFS snapshots** of entire `dbpool/arangodb` dataset
- ✅ **Instant backups** with copy-on-write (50.7GB database)
- ✅ **Automated cron setup** for nightly backups (30-day retention)
- ✅ **Documentation** with restore procedures

### Operational Snapshot System
- ✅ **Database-only backups** via arangodump (default: `include_bulk=False`)
- ✅ **CLI interface**: `python -m tools.backup.cli create/list/restore/delete/cleanup`
- ✅ **Retention policy**: Last 10, weekly for 3 months, permanent flag
- ✅ **Safety features**: Explicit confirmation required for destructive ops
- ✅ **Git tracking**: Captures commit/branch in snapshot metadata

## Implementation Details

**Core Components:**
- `tools/backup/snapshot_manager.py` (690 lines) - SnapshotManager class
- `tools/backup/cli.py` (380 lines) - Command-line interface
- `tools/backup/README.md` - Comprehensive usage documentation
- `docs/backup-strategy.md` - Two-tier strategy overview

**Technical Decisions:**

1. **TCP Endpoint for Backups** (Workaround)
   - Uses `http://127.0.0.1:8529` instead of Unix sockets
   - **Reason**: arangodump not yet supported by Go security proxies (issue #5)
   - **Trade-off**: Acceptable for backups (not time-sensitive like inference)

2. **No Bulk Storage Backup by Default**
   - Changed `include_bulk` default to `False`
   - **Reason**: `/bulk-store/metis/experiments` is already the archive

3. **Environment Variable Integration**
   - Reads `ARANGO_PASSWORD` from environment
   - Works out-of-box without additional configuration

## Test Coverage

- ✅ **26/26 unit tests passing**
- ✅ **Ruff linter**: All checks passing

## Usage Examples

### DR Backup (Instant)
```bash
# Create DR snapshot
sudo zfs snapshot dbpool/arangodb@dr_golden_image_$(date +%Y%m%d)

# Restore entire ArangoDB
sudo systemctl stop arangodb3
sudo zfs rollback dbpool/arangodb@dr_golden_image_20251007
sudo systemctl start arangodb3
```

### Operational Snapshot (On-Demand)
```bash
# Before experiment
python -m tools.backup.cli create "Before CF validation Phase 4"

# List snapshots
python -m tools.backup.cli list --verbose

# Restore
python -m tools.backup.cli restore <snapshot_name>
```

## Documentation

- [Quick Start](tools/SNAPSHOT_QUICKSTART.md)
- [Full Documentation](tools/backup/README.md)
- [Backup Strategy](docs/backup-strategy.md)

## Related Issues

- Closes #4
- References #5 (Go proxy enhancement for future)

## Checklist

- [x] Implementation complete
- [x] Tests passing (26/26)
- [x] Linting passing
- [x] Documentation complete
- [x] DR backup tested
- [ ] Operational snapshot restore test (pending golden-image)

---

@coderabbitai review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a Snapshot Manager and CLI for creating, listing, restoring, deleting, and cleaning backups with retention, compression, optional bulk storage, confirmations, and Git context.

- Documentation
  - Added comprehensive backup strategy, Snapshot Manager README, quick reference, and tooling docs.

- Tests
  - Added extensive tests covering snapshot creation, restore, compression, retention policies, and edge cases.

- Chores
  - Expanded project packaging/dependencies and added test configuration for reliable imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->